### PR TITLE
Accept a Date object in addition to strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,18 @@
  * @api public
  */
 module.exports = function currentWeekNumber(date) {
-  var instance = new Date();
+  var instance;
 
   if (typeof date === 'string' && date.length) {
     instance = new Date(date);
   }
+  else if (date instanceof Date) {
+    instance = date;
+  }
+  else {
+    instance = new Date();
+  }
+
 
   // Create a copy of this date object
   var target = new Date(instance.valueOf());

--- a/package.json
+++ b/package.json
@@ -53,8 +53,5 @@
     "istanbul-harmony": "^0.3.1",
     "mocha": "*",
     "mocha-lcov-reporter": "^0.0.1"
-  },
-  "bin": {
-    "week": "cli.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -23,6 +23,10 @@ describe('current-week-number:', function() {
     assert.strictEqual(currentWeekNumber('12/15/2014'), 51);
     done();
   });
+  it('should receive date object', function(done) {
+    assert.strictEqual(currentWeekNumber(new Date('March 24, 2015')), 13);
+    done();
+  });
   it('should get current week number when empty string format', function(done) {
     assert.strictEqual(typeof currentWeekNumber(''), 'number');
     done();


### PR DESCRIPTION
This module does exactly what I need it to do, but the dates I need to work with are already instances of Date. This patch allows one to pass a Date object as an argument to the function.